### PR TITLE
Fixed Strategist Fee Typo and Added Tests

### DIFF
--- a/contracts/StrategyConvexStables.sol
+++ b/contracts/StrategyConvexStables.sol
@@ -445,7 +445,7 @@ contract StrategyConvexStables is
             if (performanceFeeStrategist > 0) {
                 uint256 cvxCrvToStrategist =
                     cvxCrvBalance.mul(performanceFeeStrategist).div(MAX_FEE);
-                crvToken.safeTransfer(strategist, cvxCrvToStrategist);
+                cvxCrvToken.safeTransfer(strategist, cvxCrvToStrategist);
                 emit PerformanceFeeStrategist(
                     strategist,
                     cvxCrv,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,7 @@ def deploy(sett_config):
     assert want.balanceOf(deployer.address) > 0
 
     return DotMap(
+        governance=governance,
         deployer=deployer,
         controller=controller,
         sett=sett,

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -72,3 +72,121 @@ def test_are_you_trying(sett_id):
     ## Distributions are in bcvxCRV and bveCVX
     assert harvest.events["TreeDistribution"][0]["token"] == strategy.cvxCrvHelperVault()
     assert harvest.events["TreeDistribution"][1]["token"] == strategy.bveCVX()
+
+
+@pytest.mark.parametrize(
+    "sett_id",
+    sett_config.native,
+)
+def test_fee_configs(sett_id):
+    """
+    Checks the fees are processed properly according to 
+    different configurations.
+    """
+    # Setup
+    deployed = deploy(sett_config.native[sett_id])
+
+    deployer = deployed.deployer
+    governance = deployed.governance
+    sett = deployed.sett
+    want = deployed.want
+    strategy = deployed.strategy
+
+    startingBalance = want.balanceOf(deployer)
+
+    depositAmount = startingBalance // 2
+    assert startingBalance >= depositAmount
+    assert startingBalance >= 0
+    assert want.balanceOf(sett) == 0
+
+    want.approve(sett, MaxUint256, {"from": deployer})
+    sett.deposit(depositAmount, {"from": deployer})
+
+    available = sett.available()
+    assert available > 0
+
+    sett.earn({"from": deployer})
+
+    chain.sleep(10000 * 13)  # Mine so we get some interest
+
+    ## End Setup
+
+    chain.snapshot()
+
+    # TEST 1: Configures Gov Fee/Strategist Fee: 20%/0%
+    strategy.setPerformanceFeeGovernance(2000, {"from": governance})
+    strategy.setPerformanceFeeStrategist(0, {"from": governance})
+
+    harvest = strategy.harvest({"from": deployer})
+
+    ## Fees are being processed
+    assert harvest.events["PerformanceFeeGovernance"][0]["amount"] > 0
+    assert harvest.events["PerformanceFeeGovernance"][1]["amount"] > 0
+
+    ## Fail if PerformanceFeeStrategist is fired
+    try:
+        harvest.events["PerformanceFeeStrategist"]
+        assert False
+    except:
+        assert True
+
+    ## The fees are in CRV and CVX
+    assert harvest.events["PerformanceFeeGovernance"][0]["token"] == strategy.cvxCrv()
+    assert harvest.events["PerformanceFeeGovernance"][1]["token"] == strategy.cvx()
+
+
+    chain.revert()
+
+    # TEST 2: Configures Gov Fee/Strategist Fee: 10%/10%
+    strategy.setPerformanceFeeGovernance(1000, {"from": governance})
+    strategy.setPerformanceFeeStrategist(1000, {"from": governance})
+
+    harvest = strategy.harvest({"from": deployer})
+
+    ## Fees are being processed
+    assert harvest.events["PerformanceFeeGovernance"][0]["amount"] > 0
+    assert harvest.events["PerformanceFeeGovernance"][1]["amount"] > 0
+    assert harvest.events["PerformanceFeeStrategist"][0]["amount"] > 0
+    assert harvest.events["PerformanceFeeStrategist"][1]["amount"] > 0
+
+    # Both fees are equal
+    assert (
+        harvest.events["PerformanceFeeGovernance"][0]["amount"]
+    ) == (
+        harvest.events["PerformanceFeeStrategist"][0]["amount"]
+    )
+    assert (
+        harvest.events["PerformanceFeeGovernance"][1]["amount"]
+    ) == (
+        harvest.events["PerformanceFeeStrategist"][1]["amount"]
+    )
+
+    ## The fees are in CRV and CVX
+    assert harvest.events["PerformanceFeeGovernance"][0]["token"] == strategy.cvxCrv()
+    assert harvest.events["PerformanceFeeGovernance"][1]["token"] == strategy.cvx()
+    assert harvest.events["PerformanceFeeStrategist"][0]["token"] == strategy.cvxCrv()
+    assert harvest.events["PerformanceFeeStrategist"][1]["token"] == strategy.cvx()
+
+
+    chain.revert()
+
+    # TEST 3: Configures Gov Fee/Strategist Fee: 0%/20%
+    strategy.setPerformanceFeeGovernance(0, {"from": governance})
+    strategy.setPerformanceFeeStrategist(2000, {"from": governance})
+
+    harvest = strategy.harvest({"from": deployer})
+
+    ## Fees are being processed
+    assert harvest.events["PerformanceFeeStrategist"][0]["amount"] > 0
+    assert harvest.events["PerformanceFeeStrategist"][1]["amount"] > 0
+
+    ## Fail if PerformanceFeeGovernance is fired
+    try:
+        harvest.events["PerformanceFeeGovernance"]
+        assert False
+    except:
+        assert True
+
+    ## The fees are in CRV and CVX
+    assert harvest.events["PerformanceFeeStrategist"][0]["token"] == strategy.cvxCrv()
+    assert harvest.events["PerformanceFeeStrategist"][1]["token"] == strategy.cvx()


### PR DESCRIPTION
Fixed the typo causing the cvxCrv strategist fees processing fail and added unit tests for three different fee configuration scenarios in order for errors such as this one to be caught in the future.